### PR TITLE
Rewrite migrate command to convert JSON nodes to Markdown with YAML frontmatter

### DIFF
--- a/internal/cli/interactive/common/testdata/.zamm/nodes/201c7092-9367-4a97-837b-98fbbcd7168a.md
+++ b/internal/cli/interactive/common/testdata/.zamm/nodes/201c7092-9367-4a97-837b-98fbbcd7168a.md
@@ -1,0 +1,7 @@
+---
+id: 201c7092-9367-4a97-837b-98fbbcd7168a
+title: Hello World
+type: specification
+---
+
+The program should print out "Hello World"

--- a/internal/cli/interactive/common/testdata/.zamm/nodes/3e6eec1d-c622-42a5-8fe5-88151ba97090.md
+++ b/internal/cli/interactive/common/testdata/.zamm/nodes/3e6eec1d-c622-42a5-8fe5-88151ba97090.md
@@ -1,0 +1,7 @@
+---
+id: 3e6eec1d-c622-42a5-8fe5-88151ba97090
+title: Hello World Function
+type: specification
+---
+
+Function should be named `hello_world`

--- a/internal/cli/interactive/common/testdata/.zamm/nodes/4c09428a-ce7e-43d0-85da-6f671453c06f.md
+++ b/internal/cli/interactive/common/testdata/.zamm/nodes/4c09428a-ce7e-43d0-85da-6f671453c06f.md
@@ -1,0 +1,8 @@
+---
+id: 4c09428a-ce7e-43d0-85da-6f671453c06f
+implementations: []
+title: Test Project
+type: project
+---
+
+This project is meant to help tests pass

--- a/internal/cli/interactive/common/testdata/.zamm/nodes/eb76cdc6-f24c-432a-bfa3-c2ac3257146c.md
+++ b/internal/cli/interactive/common/testdata/.zamm/nodes/eb76cdc6-f24c-432a-bfa3-c2ac3257146c.md
@@ -1,0 +1,8 @@
+---
+branch: rust
+id: eb76cdc6-f24c-432a-bfa3-c2ac3257146c
+title: Rust Implementation
+type: implementation
+---
+
+This is an implementation of the project in Rust

--- a/internal/cli/interactive/common/testdata/.zamm/nodes/f38191af-1b23-4129-854b-5ba754a30c3c.md
+++ b/internal/cli/interactive/common/testdata/.zamm/nodes/f38191af-1b23-4129-854b-5ba754a30c3c.md
@@ -1,0 +1,11 @@
+---
+id: f38191af-1b23-4129-854b-5ba754a30c3c
+title: Lorem Ipsum command should print a few paragraphs of Lorem Ipsum
+type: specification
+---
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum cursus consequat enim sed aliquet. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Pellentesque leo sem, sollicitudin vitae volutpat nec, molestie ut ligula. Cras nisi lacus, interdum nec nisl vel, posuere blandit tellus. Mauris ut arcu et massa varius vehicula id id felis. Suspendisse interdum ultricies quam vel convallis. Interdum et malesuada fames ac ante ipsum primis in faucibus. Praesent orci sem, maximus quis lacus consectetur, efficitur porttitor ex. Donec non lobortis quam. Proin nisi metus, interdum at est et, ultrices efficitur arcu.
+
+Suspendisse potenti. Pellentesque libero tortor, ornare eu condimentum at, tempus et ante. Vestibulum quis nulla arcu. Donec iaculis ipsum id enim pulvinar pulvinar. Pellentesque eu semper mauris, nec faucibus felis. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Proin ut dapibus tellus, quis dignissim diam. Ut hendrerit vitae orci vitae maximus.
+
+Nullam quis urna fringilla, bibendum odio et, sodales neque. Proin erat libero, elementum in magna id, lobortis ultrices ante. Vivamus quis augue vitae lectus hendrerit finibus in laoreet augue. Donec consectetur nisl neque, sollicitudin pellentesque nisi tempus eget. Ut eu dolor non mauris feugiat tempus sit amet ut velit. Sed mattis eget nunc sed varius. Vestibulum in libero a mauris fermentum dignissim. Morbi cursus consequat placerat. Nunc efficitur sem at ligula semper, non dapibus justo tincidunt. Praesent tristique semper nisl, in eleifend mauris efficitur vitae. Nam gravida elit sem, vel accumsan metus dictum quis. Integer nibh turpis, tristique ut sem tempor, convallis tincidunt eros. Vivamus vestibulum massa sed lorem maximus, vitae ullamcorper lorem dictum.


### PR DESCRIPTION
# Rewrite migrate command to convert JSON nodes to Markdown with YAML frontmatter

## Summary

This PR completely rewrites the `migrate` command functionality. Previously, the command only renamed the `specs` folder to `nodes`. Now it converts all JSON files in the `.zamm/nodes` directory to Markdown files with YAML frontmatter, where the `content` field becomes the markdown body and all other JSON attributes become frontmatter.

**Key Changes:**
- Added YAML library import (`gopkg.in/yaml.v3`)
- Completely rewrote `migrateSpecsToNodes()` function with new JSON-to-Markdown conversion logic
- Added new `convertJSONToMarkdown()` helper function
- Updated command description and success messages
- Enhanced error handling for the new conversion process
- Tested with sample data (5 JSON files successfully converted)

**Breaking Change:** This fundamentally changes what the `migrate` command does - from folder renaming to file format conversion.

## Review & Testing Checklist for Human

- [ ] **Verify requirement alignment**: Confirm this breaking change to migrate command behavior matches the intended requirements
- [ ] **Test with real user data**: Run migration on actual `.zamm/nodes` directories to ensure no data loss or corruption occurs
- [ ] **Validate YAML frontmatter**: Check that generated Markdown files have properly formatted, parseable YAML frontmatter
- [ ] **Test idempotency**: Verify running migrate multiple times doesn't break (should skip existing .md files)
- [ ] **Test edge cases**: Try with malformed JSON, read-only files, empty content fields, and special characters in JSON values

**Recommended Test Plan:**
1. Back up a real `.zamm/nodes` directory
2. Run `./bin/zamm migrate` and verify all JSON files are converted
3. Manually inspect a few generated .md files for correct structure
4. Try parsing the YAML frontmatter with a YAML parser
5. Run migrate again to confirm it skips existing files
6. Test with edge cases (empty files, special characters, etc.)

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    CLI["internal/cli/system_commands.go<br/>(MAJOR EDIT)"]:::major-edit
    Storage["internal/storage/filestorage.go<br/>(Context - JSON utilities)"]:::context
    Models["internal/models/models.go<br/>(Context - Node structures)"]:::context
    TestData["testdata/.zamm/nodes/<br/>(New .md files)"]:::minor-edit
    
    CLI --> |"reads JSON files"| Storage
    CLI --> |"uses Node types"| Models
    CLI --> |"converts to"| TestData
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#ADD8E6
    classDef context fill:#FFFFFF
```

### Notes


- The conversion preserves all JSON fields as YAML frontmatter except `content`, which becomes the markdown body
- Supports all node types (specification, implementation, project) with their specific fields like `branch`, `repo_url`, `folder_path`
- Uses existing `readJSONFile` patterns from the codebase for consistency
- Migration is designed to be idempotent - skips files that already have corresponding .md files

**Session Info:**
- Requested by: Amos Ng (@amosjyng)
- Link to Devin run: https://app.devin.ai/sessions/6780d47390ab412c8633d6118098e135