### PR TITLE
Add 'o' key binding for organize with slug editor

### DIFF
--- a/internal/cli/interactive/common/slug_editor.go
+++ b/internal/cli/interactive/common/slug_editor.go
@@ -1,0 +1,114 @@
+package common
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+type SlugEditorCompleteMsg struct {
+	Slug string
+}
+
+type SlugEditorCancelMsg struct{}
+
+type SlugEditor struct {
+	title     string
+	nodeTitle string
+	input     textinput.Model
+	width     int
+	height    int
+}
+
+func NewSlugEditor(title, nodeTitle, initialSlug string) SlugEditor {
+	input := textinput.New()
+	input.Placeholder = "Enter slug for organization"
+	input.Focus()
+	input.SetValue(initialSlug)
+	input.Width = 50
+
+	return SlugEditor{
+		title:     title,
+		nodeTitle: nodeTitle,
+		input:     input,
+	}
+}
+
+func (s SlugEditor) Init() tea.Cmd {
+	return textinput.Blink
+}
+
+// SetSize sets the dimensions of the slug editor
+func (s *SlugEditor) SetSize(width, height int) {
+	s.width = width
+	s.height = height
+	s.input.Width = width - 4
+}
+
+// Update handles tea messages and updates the component
+func (s SlugEditor) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		s.SetSize(msg.Width, msg.Height)
+		return s, nil
+	case tea.KeyMsg:
+		switch msg.Type {
+		case tea.KeyCtrlC, tea.KeyEsc:
+			return s, func() tea.Msg {
+				return SlugEditorCancelMsg{}
+			}
+		case tea.KeyEnter:
+			slug := strings.TrimSpace(s.input.Value())
+			if slug == "" {
+				return s, nil
+			}
+			return s, func() tea.Msg {
+				return SlugEditorCompleteMsg{
+					Slug: slug,
+				}
+			}
+		}
+	}
+
+	var cmd tea.Cmd
+	s.input, cmd = s.input.Update(msg)
+	return s, cmd
+}
+
+func (s SlugEditor) View() string {
+	var sb strings.Builder
+
+	sb.WriteString(s.title + "\n")
+	sb.WriteString(strings.Repeat("=", len(s.title)) + "\n\n")
+
+	sb.WriteString("Node: " + s.nodeTitle + "\n\n")
+
+	sb.WriteString("Edit the slug that will be used for organizing this node:\n\n")
+
+	sb.WriteString(s.input.View() + "\n\n")
+
+	sb.WriteString("Press Enter to organize with this slug, Esc to cancel")
+
+	content := sb.String()
+	style := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder(), true).
+		BorderForeground(lipgloss.Color("6")).
+		Padding(1, 2).
+		Width(s.width - 4).
+		Align(lipgloss.Center)
+
+	return lipgloss.Place(s.width, s.height, lipgloss.Center, lipgloss.Center, style.Render(content))
+}
+
+func sanitizeSlug(title string) string {
+	slug := strings.ToLower(title)
+	slug = regexp.MustCompile(`[^a-z0-9]+`).ReplaceAllString(slug, "-")
+	slug = strings.Trim(slug, "-")
+	if slug == "" {
+		slug = "untitled"
+	}
+	return slug
+}

--- a/internal/cli/interactive/common/slug_editor.go
+++ b/internal/cli/interactive/common/slug_editor.go
@@ -1,7 +1,6 @@
 package common
 
 import (
-	"regexp"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/textinput"
@@ -101,14 +100,4 @@ func (s SlugEditor) View() string {
 		Align(lipgloss.Center)
 
 	return lipgloss.Place(s.width, s.height, lipgloss.Center, lipgloss.Center, style.Render(content))
-}
-
-func sanitizeSlug(title string) string {
-	slug := strings.ToLower(title)
-	slug = regexp.MustCompile(`[^a-z0-9]+`).ReplaceAllString(slug, "-")
-	slug = strings.Trim(slug, "-")
-	if slug == "" {
-		slug = "untitled"
-	}
-	return slug
 }

--- a/internal/cli/interactive/nodes/explorer.go
+++ b/internal/cli/interactive/nodes/explorer.go
@@ -12,18 +12,19 @@ import (
 )
 
 type keyMap struct {
-	Up     key.Binding
-	Down   key.Binding
-	Select key.Binding
-	Create key.Binding
-	Edit   key.Binding
-	Delete key.Binding
-	Link   key.Binding
-	Remove key.Binding
-	Move   key.Binding
-	Help   key.Binding
-	Back   key.Binding
-	Quit   key.Binding
+	Up       key.Binding
+	Down     key.Binding
+	Select   key.Binding
+	Create   key.Binding
+	Edit     key.Binding
+	Delete   key.Binding
+	Link     key.Binding
+	Remove   key.Binding
+	Move     key.Binding
+	Organize key.Binding
+	Help     key.Binding
+	Back     key.Binding
+	Quit     key.Binding
 }
 
 var keys = keyMap{
@@ -67,6 +68,10 @@ var keys = keyMap{
 		key.WithKeys("m", "M"),
 		key.WithHelp("m", "move"),
 	),
+	Organize: key.NewBinding(
+		key.WithKeys("o", "O"),
+		key.WithHelp("o", "organize"),
+	),
 	Quit: key.NewBinding(
 		key.WithKeys("q", "Q"),
 		key.WithHelp("q", "quit"),
@@ -87,7 +92,7 @@ func (k keyMap) FullHelp() [][]key.Binding {
 		{k.Select, k.Back},
 		{k.Create, k.Edit, k.Delete},
 		{k.Link, k.Remove, k.Move},
-		{k.Help, k.Quit},
+		{k.Organize, k.Help, k.Quit},
 	}
 }
 
@@ -205,6 +210,8 @@ func (e *NodeExplorer) Update(msg tea.Msg) (NodeExplorer, tea.Cmd) {
 			return *e, func() tea.Msg { return RemoveLinkSpecMsg{SpecID: e.activeSpec.GetID()} }
 		case key.Matches(msg, e.keys.Move):
 			return *e, func() tea.Msg { return MoveSpecMsg{SpecID: e.activeSpec.GetID()} }
+		case key.Matches(msg, e.keys.Organize):
+			return *e, func() tea.Msg { return OrganizeSpecMsg{SpecID: e.activeSpec.GetID()} }
 		case key.Matches(msg, e.keys.Back):
 			// If a child is selected, clear selection
 			if e.leftPane.GetSelectedChild() != nil {

--- a/internal/cli/interactive/nodes/messages.go
+++ b/internal/cli/interactive/nodes/messages.go
@@ -25,4 +25,8 @@ type MoveSpecMsg struct {
 	SpecID string
 }
 
+type OrganizeSpecMsg struct {
+	SpecID string
+}
+
 type ExitMsg struct{}


### PR DESCRIPTION
# Add 'o' key binding for organize with slug editor

## Summary

This PR implements the requested feature to add an 'o' key binding in interactive mode that organizes the selected node. When a node doesn't have a slug, it displays a slug editor screen allowing the user to edit the autogenerated slug before proceeding with the organize operation.

**Key Changes:**
- Added `OrganizeSpecMsg` message type for organize workflow
- Added 'o' key binding to the NodeExplorer keyMap with help text
- Created new `SlugEditor` component following existing TUI patterns (similar to NodeEditor)
- Added `SlugEditor` state to main interactive model with proper message handling
- Integrated with existing `OrganizeNodes` service method
- Added slug generation and sanitization helper functions

**Workflow:**
1. User presses 'o' on a node in interactive mode
2. If node has no slug → show SlugEditor with autogenerated slug for editing
3. If node has slug → organize directly
4. SlugEditor allows editing slug or canceling with Esc
5. On completion, sets slug on node and calls organize operation

## Review & Testing Checklist for Human

- [ ] **Test organize functionality end-to-end** - The core feature worked in testing but there was a display issue after organize completion where the TUI got stuck in a loop. Verify the TUI returns to normal state after organizing.
- [ ] **Test edge cases** - Cancel from slug editor with Esc, organize nodes that already have slugs (should skip editor), test with empty/invalid slug inputs
- [ ] **Test with different node types** - Verify organize works correctly with specifications, projects, and implementations
- [ ] **Review state transition logic** - Check the SlugEditor state transitions in `interactive.go` for correctness, especially error handling paths

**Recommended Test Plan:**
1. Build and run `./bin/zamm interactive` in a test directory
2. Create test nodes with `zamm spec create --title "Test" --content "Content"`
3. Navigate to nodes and press 'o' to test organize workflow
4. Test both paths: nodes without slugs (should show editor) and nodes with slugs (should organize directly)
5. Verify TUI remains stable and responsive after organize operations complete

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    Explorer["internal/cli/interactive/nodes/<br/>explorer.go"]:::minor-edit
    Messages["internal/cli/interactive/nodes/<br/>messages.go"]:::minor-edit
    Interactive["internal/cli/interactive.go"]:::major-edit
    SlugEditor["internal/cli/interactive/common/<br/>slug_editor.go"]:::major-edit
    SpecService["internal/services/spec.go<br/>(OrganizeNodes method)"]:::context
    
    Explorer -->|"'o' key binding"| Messages
    Messages -->|"OrganizeSpecMsg"| Interactive
    Interactive -->|"creates if no slug"| SlugEditor
    SlugEditor -->|"SlugEditorCompleteMsg"| Interactive
    Interactive -->|"calls organize"| SpecService
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end

classDef major-edit fill:#90EE90
classDef minor-edit fill:#87CEEB
classDef context fill:#FFFFFF
```

### Notes

- **Testing Status**: Build ✅, Unit tests ✅, Manual testing revealed core functionality works but encountered display issue after organize completion
- **Integration**: Reuses existing `OrganizeNodes` service method and follows established TUI patterns
- **Session**: Requested by Amos Ng (@amosjyng) - https://app.devin.ai/sessions/e0b37112ad8947f9ba8658f56b621f96

**⚠️ Known Issue**: During manual testing, the TUI got stuck in a display loop after the organize operation completed. The core organize functionality worked (slug editor appeared, slug could be edited, organize operation executed), but the display issue needs investigation before merging.